### PR TITLE
Remove for loop branch

### DIFF
--- a/AssignmentTwo/AssignmentTwo/Validators/AndValidator.swift
+++ b/AssignmentTwo/AssignmentTwo/Validators/AndValidator.swift
@@ -15,12 +15,6 @@ struct AndValidator<Value> : Validator {
     }
 
     func validate(_ value: Value) -> Bool {
-        for child in children {
-            if !child.validate(value) {
-                return false
-            }
-        }
-
-        return true
+        return children.first { !$0.validate(value) } == nil
     }
 }

--- a/AssignmentTwo/AssignmentTwo/Validators/OrValidator.swift
+++ b/AssignmentTwo/AssignmentTwo/Validators/OrValidator.swift
@@ -15,12 +15,6 @@ struct OrValidator<Value> : Validator {
     }
 
     func validate(_ value: Value) -> Bool {
-        for child in children {
-            if child.validate(value) {
-                return true
-            }
-        }
-
-        return false
+        return children.first { $0.validate(value) } != nil
     }
 }


### PR DESCRIPTION
So... here's a question:

Why is the first parameter name (in this case, "where") *often* optional?

I thought only the first parameter name, when it's explicitly labeled "_", could be left out.

I originally wrote the OR validator's body as:

```
return children.first(where: { $0.validate(value) }) != nil
```

But I committed it as:

```
return children.first { $0.validate(value) } != nil
```

per your suggestion.

So I just would like to understand this syntax nuance.